### PR TITLE
Relate between tables movimiento and agenda, update dashboard/view

### DIFF
--- a/controllers/dashboard.py
+++ b/controllers/dashboard.py
@@ -41,7 +41,8 @@ def view():
             db.agenda.titulo,
             db.agenda.vencimiento,
             db.agenda.prioridad,
-            db.agenda.estado],
+            db.agenda.estado,
+            db.agenda.expediente_id],
         orderby=db.agenda.vencimiento,
         paginate=9,
         maxtextlength=40,
@@ -58,7 +59,8 @@ def view():
             db.agenda.titulo,
             db.agenda.vencimiento,
             db.agenda.prioridad,
-            db.agenda.estado],
+            db.agenda.estado,
+            db.agenda.expediente_id],
         orderby=db.agenda.vencimiento,
         paginate=9,
         maxtextlength=40,
@@ -85,3 +87,4 @@ def view():
                         'img': 'juzgados.png', 'alt': T('Oficinas judiciales')})
 
     return locals()
+

--- a/models/db_pydoctor.py
+++ b/models/db_pydoctor.py
@@ -331,6 +331,9 @@ db.define_table(
         label=T('Texto'),
         widget=advanced_editor,
         represent=advanced_repr),
+    Field('movimiento_id',
+        db.movimiento,
+        label=T('Movimiento')),
     auth.signature)
 
 db.agenda.id.readable = db.agenda.id.writable = False

--- a/views/dashboard/view.html
+++ b/views/dashboard/view.html
@@ -50,7 +50,7 @@ __copyright__ = "(C) 2016 María Andrea Vignau. GNU GPL 3."
     {{=CAT(reference)}}
     <div class="panel panel-success">
       <div class="panel-heading">
-        <h3 class="panel-title">Tareas pendientes</h3>
+        <h3 class="panel-title">Tareas pendientes de la semana</h3>
       </div>
       <div class="panel-body">
         {{=semanal_grid}}

--- a/views/expedientes/index.html
+++ b/views/expedientes/index.html
@@ -25,3 +25,10 @@
     $('#parte_caracter').width('25%')
 
 </script>
+<script>
+    $(function() {
+        $("td>a>span").each(function() {
+            if ($(this).html()=="Agendas")
+                $(this).parent().css('display','none');
+        });
+    });</script>


### PR DESCRIPTION
## Resumen

This PR add a relation between the table movimiento and agenda, making it possible to schedule a movement optionally. It also clarifies the timing of urgent tasks 

## Checklist

- [x] Verified PEP8

## Screenshots

![Captura de pantalla de 2021-06-07 21-35-02](https://user-images.githubusercontent.com/73370773/121914118-5d14aa80-cd08-11eb-8e72-0503ad0944c0.png)
