### PR TITLE
Share data between user group

### DIFF
--- a/controllers/expedientes.py
+++ b/controllers/expedientes.py
@@ -12,6 +12,11 @@ ZIP_FILENAME = 'Movimiento.zip'
 CHUNK_SIZE = 4096
 
 
+def group():
+    group_name=db(db.auth_group.role).select().first()
+    return group_name
+    
+
 @auth.requires_login()
 def index():
     'muestra la grilla y permite la edición de los datos de los expedientes'
@@ -55,7 +60,7 @@ def index():
         ],
         constraints={
             'expediente': (
-                db.expediente.created_by == auth.user.id)},
+                db.expediente.created_by_group == group())},
         linked_tables=LINKED_TABLES,
         buttons_placement='right',
         exportclasses=myexport,

--- a/models/db_pydoctor.py
+++ b/models/db_pydoctor.py
@@ -164,6 +164,14 @@ def expediente_numero(value, row):
     return anchor
 
 
+def get_group():
+    groups = auth.user_groups
+    if not groups:
+        return None
+    group_ids = [id for id in groups if not groups[id].startswith('user_')]
+    return group_ids[0] if group_ids else None
+    
+
 db.define_table('expediente',
                 Field('numero', length=40,
                       requires=IS_NOT_IN_DB(db, 'expediente.numero'),
@@ -179,6 +187,7 @@ db.define_table('expediente',
                 Field('final', 'date', label=T('Fecha fin')),
                 Field('changed_at', 'datetime',
                       update=request.now, readable=False, writable=False),
+                Field('created_by_group', 'reference auth_group', default=get_group(), update=get_group(), writable=False ),
                 auth.signature, migrate=True,
                 format=expediente_format)
 


### PR DESCRIPTION
## Summary

close https://github.com/Juerodriguez/OpenLex/issues/25
This PR follow the development line of the https://github.com/PyAr/OpenLex/issues/11 adding the possibility of visualizing the data shared between the users of the same group 

## Checklist

- [x] Variables, funciones y comentarios en Español
- [x] Corrector ortográfico ok
- [x] Cdigo Python cumple PEP8
- [x] Cobertura de tests con Playwright
- [x] Revisores asignados (pares & al menos 1 mentor)

## Screenshots

(vista rápida, preferir png, gif animado y/o video de Playwright)
